### PR TITLE
Make Binance API credentials optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project demonstrates a Proof of Concept (PoC) for crypto trading strategy b
 
 ### Features
 
-- **Binance API** integration for historical data retrieval.
+- **Binance API** integration for historical data retrieval (API keys optional for the sample scripts).
 - A **simple PoC trading strategy** to showcase both frameworks.
 - Comparative tests to highlight performance and visualization differences.
 - Clear modular structure for future scaling and Docker integration.
@@ -22,3 +22,6 @@ In quick comparisons over a 3-month historical range at 1-hour intervals, the di
 For **faster iteration** in repeated backtests, we will:
 - Use the **Direct Binance API** for data download.
 - Save fetched data to a **temporary Parquet file**, so we can skip re-fetching from the exchange on subsequent runs.
+
+> **Note:** All historical market-data endpoints used in this project are public. Binance API keys can still be supplied via the
+> `BINANCE_API_KEY` and `BINANCE_API_SECRET` environment variables (or a `.env` file) if you have them, but they are optional.

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,7 @@
 # src/config/config.py
 
 from pathlib import Path
+from typing import Optional
 
 from emrpy import get_root_path
 from pydantic import Field
@@ -18,9 +19,9 @@ class Settings(BaseSettings):
     ccxt_data_symbol: str = 'BTC/USDT'
     binance_data_symbol: str = 'BTCUSDT'
 
-    # Credentials (not required for this example)
-    # binance_api_key: str = Field(default="BINANCE_API_KEY", env="BINANCE_API_KEY")
-    # binance_api_secret: str = Field(default="BINANCE_API_SECRET", env="BINANCE_API_SECRET")
+    # Credentials (optional for public-market data requests)
+    binance_api_key: Optional[str] = Field(default=None, env="BINANCE_API_KEY")
+    binance_api_secret: Optional[str] = Field(default=None, env="BINANCE_API_SECRET")
 
     # Root path
     root_path: Path = Field(get_root_path(0))

--- a/src/data/binance_api_downloader.py
+++ b/src/data/binance_api_downloader.py
@@ -10,6 +10,13 @@ class BinanceDirectDownloader:
     """
 
     def __init__(self, api_key=None, api_secret=None):
+        """Create a python-binance client.
+
+        Binance exposes historical price data through public endpoints, so
+        credentials are optional. Supplying them may still be beneficial for
+        installations that have higher rate-limit needs.
+        """
+
         self.client = Client(api_key, api_secret)
 
     def fetch_ohlcv(

--- a/src/data/ccxt_data_downloader.py
+++ b/src/data/ccxt_data_downloader.py
@@ -4,12 +4,21 @@ import polars as pl
 
 class ccxtBinanceDataDownloader:
     def __init__(self, api_key=None, api_secret=None):
+        """Initialize the Binance exchange object via CCXT.
+
+        Args:
+            api_key: Optional Binance API key. Public data requests do not
+                require credentials, but providing them may grant higher
+                rate limits.
+            api_secret: Optional Binance API secret to pair with the key.
         """
-        Initialize the Binance exchange object via CCXT.
-        Keys optional for public data, but you can provide
-        them if Binance imposes stricter rate limits.
-        """
-        self.exchange = ccxt.binance({"apiKey": api_key, "secret": api_secret})
+        exchange_config: dict[str, str] = {}
+        if api_key:
+            exchange_config["apiKey"] = api_key
+        if api_secret:
+            exchange_config["secret"] = api_secret
+
+        self.exchange = ccxt.binance(exchange_config)
 
     def fetch_ohlcv(
         self, symbol: str, timeframe: str = "1h", limit: int | None = None, since=None

--- a/src/data/data_pipeline.py
+++ b/src/data/data_pipeline.py
@@ -40,6 +40,9 @@ def ccxt_fetch():
              config.ccxt_data_symbol, config.data_timeframe)
     start_ms, end_ms = calc_dates()
 
+    if not config.binance_api_key or not config.binance_api_secret:
+        log.debug("Binance API credentials not provided; proceeding without authentication.")
+
     ccxt_client = ccxtBinanceDataDownloader(
         api_key=config.binance_api_key,
         api_secret=config.binance_api_secret
@@ -60,6 +63,9 @@ def binance_direct_fetch():
     log.info("Starting direct Binance fetch for symbol %s with interval %s",
              config.binance_data_symbol, config.data_timeframe)
     start_ms, end_ms = calc_dates()
+
+    if not config.binance_api_key or not config.binance_api_secret:
+        log.debug("Binance API credentials not provided; proceeding without authentication.")
 
     direct_client = BinanceDirectDownloader(
         api_key=config.binance_api_key,


### PR DESCRIPTION
## Summary
- add optional Binance API credential fields to the shared settings and data downloaders
- clarify downloader behaviour and docs when credentials are absent
- log when unauthenticated requests are used while keeping CCXT/python-binance setup flexible

## Testing
- `python -m compileall src main.py`


------
https://chatgpt.com/codex/tasks/task_e_68d3a2f7289c8326a527c555be045b14